### PR TITLE
Boostrap через bower

### DIFF
--- a/client/bower.json
+++ b/client/bower.json
@@ -19,6 +19,8 @@
     "jquery": "~2.1.1",
     "backbone": "~1.1.2",
     "underscore": "~1.7.0",
-    "bootstrap": "~3.2.0"
+    "bootstrap": "~3.2.0",
+    "bootstrap-css": "2.3.2",
+    "font-awesome-css": "~4.0.3"
   }
 }

--- a/client/index.html
+++ b/client/index.html
@@ -7,9 +7,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="">
-    <link rel="stylesheet" type="text/css" href="lib/bootstrap/css/bootstrap.css">
+    <link rel="stylesheet" type="text/css" href="components/bootstrap-css/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="stylesheets/theme.css">
-    <link rel="stylesheet" href="lib/font-awesome/css/font-awesome.css">
+    <link rel="stylesheet" type="text/css" href="components/font-awesome-css/css/font-awesome.min.css">
 
     <!-- Bower components -->
     <script src="components/jquery/dist/jquery.min.js" type="text/javascript"></script>


### PR DESCRIPTION
Использовать полностьб содержимое `comonents/bootstrap` не получилось, только _js_. Стили завязаны на `bootstrap 2.1.1`, а _bower_ поставил свежий `bootstrap 3.2.0`. Нужно перебирать стили и только после этого можно убрать _bootstrap_ из `clients/lib/`.
